### PR TITLE
Add documentation & support for :put

### DIFF
--- a/autoload/fauxClip.vim
+++ b/autoload/fauxClip.vim
@@ -51,9 +51,12 @@ function! fauxClip#cmd(cmd, reg) range
     let range = a:firstline . ',' . a:lastline
     call fauxClip#start(a:reg)
     execute range . a:cmd
+    if !exists('##TextYankPost')
+        doautocmd CursorMoved
+    endif
 endfunction
 
 function! fauxClip#cmd_wrapper()
-    let cmd = substitute(getcmdline(), '\<\(y\%[ank]\|d\%[elete]\|p\%[ut]!\?\)\s*\([+*]\)', 'call fauxClip#cmd(''\1'', ''\2'')', 'g')
+    let cmd = substitute(getcmdline(), '\<\(y\%[ank]\|d\%[elete]\|pu\%[t]!\?\)\s*\([+*]\)', 'call fauxClip#cmd(''\1'', ''\2'')', 'g')
     execute cmd
 endfunction

--- a/autoload/fauxClip.vim
+++ b/autoload/fauxClip.vim
@@ -50,6 +50,6 @@ function! fauxClip#cmd(cmd, reg) range
 endfunction
 
 function! fauxClip#cmd_wrapper()
-    let cmd = substitute(getcmdline(), '\<\(y[%[ank]\|d\%[elete]\|p\%[ut]!\?\)\s*\([+\*]\)', 'call fauxClip#cmd(''\1'', ''\2'')', 'g')
+    let cmd = substitute(getcmdline(), '\<\(y\%[ank]\|d\%[elete]\|p\%[ut]!\?\)\s*\([+*]\)', 'call fauxClip#cmd(''\1'', ''\2'')', 'g')
     execute cmd
 endfunction

--- a/autoload/fauxClip.vim
+++ b/autoload/fauxClip.vim
@@ -10,7 +10,11 @@ function! fauxClip#start(REG)
 
     augroup fauxClip
         autocmd!
-        autocmd TextYankPost * if v:event.regname == '"' | call fauxClip#yank(v:event.regcontents, s:REG) | endif
+        if exists('##TextYankPost')
+              autocmd TextYankPost * if v:event.regname == '"' | call fauxClip#yank(v:event.regcontents, s:REG) | endif
+          else
+              autocmd CursorMoved  * if @@ != s:reg | call fauxClip#yank(@@, s:REG) | endif
+        endif
         autocmd TextChanged  * call fauxClip#end()
     augroup END
 

--- a/autoload/fauxClip.vim
+++ b/autoload/fauxClip.vim
@@ -4,6 +4,7 @@
 function! fauxClip#start(REG)
     let s:REG = a:REG
     let s:reg = getreg('"')
+    let s:regtype = getregtype('"')
 
     let @@ = fauxClip#paste(s:REG)
 
@@ -38,8 +39,8 @@ function! fauxClip#end()
     augroup fauxClip
         autocmd!
     augroup END
-    call setreg('"', s:reg)
-    unlet! s:reg s:REG
+    call setreg('"', s:reg, s:regtype)
+    unlet! s:reg s:regtype s:REG
 endfunction
 
 function! fauxClip#cmd_wrapper()

--- a/autoload/fauxClip.vim
+++ b/autoload/fauxClip.vim
@@ -9,8 +9,8 @@ function! fauxClip#start(REG)
 
     augroup fauxClip
         autocmd!
-        autocmd TextYankPost * ++once if v:event.regname == '"' | call fauxClip#yank(v:event.regcontents, s:REG) | endif
-        autocmd TextChanged  * ++once call fauxClip#end()
+        autocmd TextYankPost * if v:event.regname == '"' | call fauxClip#yank(v:event.regcontents, s:REG) | endif
+        autocmd TextChanged  * call fauxClip#end()
     augroup END
 
     return '""'

--- a/autoload/fauxClip.vim
+++ b/autoload/fauxClip.vim
@@ -43,10 +43,13 @@ function! fauxClip#end()
     unlet! s:reg s:regtype s:REG
 endfunction
 
+function! fauxClip#cmd(cmd, reg) range
+    let range = a:firstline . ',' . a:lastline
+    call fauxClip#start(a:reg)
+    execute range . a:cmd
+endfunction
+
 function! fauxClip#cmd_wrapper()
-    command! -bar -range -nargs=1 FauxClipY execute "<line1>,<line2>!".expand('<args>' == '*' ? g:fauxClip_copy_primary_cmd : g:fauxClip_copy_cmd) | if &mod | undo | endif
-    command! -bar -range -nargs=1 FauxClipD execute "<line1>,<line2>!".expand('<args>' == '*' ? g:fauxClip_copy_primary_cmd : g:fauxClip_copy_cmd) | execute "<line1>,<line2>d _"
-    execute substitute(getcmdline(), '\(y\|ya\|yank\?\|d\|de\|del\|dele\|delete\?\)\s*\([+\*]\)', '\="FauxClip".toupper(submatch(1)[0])." ".submatch(2)', 'g')
-    setlocal nomodifiable
-    call timer_start(0, {-> execute("delc FauxClipY | delc FauxClipD | setlocal modifiable | redraw!")})
+    let cmd = substitute(getcmdline(), '\<\(y[%[ank]\|d\%[elete]\|p\%[ut]!\?\)\s*\([+\*]\)', 'call fauxClip#cmd(''\1'', ''\2'')', 'g')
+    execute cmd
 endfunction

--- a/doc/fauxClip.vim
+++ b/doc/fauxClip.vim
@@ -1,0 +1,48 @@
+*fauxClip.txt*   Clipboard support for Vim without +clipboard
+
+Author:  Jorengarenar                                        *fauxClip-author*
+
+This plugin is only available if 'compatible' is not set and no |+clipboard|
+support.
+
+==============================================================================
+                                                                    *fauxClip*
+
+fauxClip is a Vim plugin to provide a pseudo clipboard support for versions of
+Vim compiled without +clipboard
+
+==============================================================================
+
+fauxClip customization                             *fauxClip-customization*
+
+fuaxClip will need both a copy command and paste command in order to mimimic
+clipboard support.
+
+
+Primary Clipboard                                         *fauxClip-quotestar*
+
+Copy Command:
+
+  let g:fauxClip_copy_primary_cmd = 'xclip -f -i'
+
+Paste Command:
+
+  let g:fauxClip_paste_primary_cmd = 'xclip -o 2> /dev/null'
+
+
+
+X11 Selection                           *fauxClip-quoteplus* *fauxClip-quote+*
+
+Copy Command:
+
+  let g:fauxClip_copy_cmd = 'xclip -f -i -selection clipboard'
+
+
+Paste Command:
+
+  let g:fauxClip_paste_cmd = 'xclip -o -selection clipboard 2> /dev/null'
+
+
+==============================================================================
+
+ vim:tw=78:ts=8:ft=help:norl:

--- a/plugin/fauxClip.vim
+++ b/plugin/fauxClip.vim
@@ -21,7 +21,10 @@ if !exists('g:fauxClip_paste_primary_cmd')
     let g:fauxClip_paste_primary_cmd = 'xclip -o 2> /dev/null'
 endif
 
-autocmd CmdlineLeave : if getcmdline() =~ "[dy].*[+*]" | call fauxClip#cmd_wrapper() | endif
+augroup fauxClipCmdWrapper
+  autocmd!
+  autocmd CmdlineLeave : if getcmdline() =~ "[dy].*[+*]" | call fauxClip#cmd_wrapper() | endif
+augroup END
 
 nnoremap <expr> "* fauxClip#start("*")
 nnoremap <expr> "+ fauxClip#start("+")

--- a/plugin/fauxClip.vim
+++ b/plugin/fauxClip.vim
@@ -1,7 +1,7 @@
 " fauxClip - Clipboard support without +clipboard
 " Maintainer:  Jorengarenar <https://joren.ga>
 
-if &cp || has("clipboard") || exists('g:loaded_fauxClip') || !exists('##TextYankPost') || !exists('##TextChanged') || !exists('##CmdlineLeave')
+if &cp || has("clipboard") || exists('g:loaded_fauxClip') || !exists('##TextChanged') || !exists('##CmdlineLeave')
     finish
 endif
 

--- a/plugin/fauxClip.vim
+++ b/plugin/fauxClip.vim
@@ -6,19 +6,35 @@ if &cp || has("clipboard") || exists('g:loaded_fauxClip') || !exists('##TextYank
 endif
 
 if !exists('g:fauxClip_copy_cmd')
-    let g:fauxClip_copy_cmd = 'xclip -f -i -selection clipboard'
+    if executable('pbcopy')
+        let g:fauxClip_copy_cmd = 'pbcopy'
+    else
+        let g:fauxClip_copy_cmd = 'xclip -f -i -selection clipboard'
+    endif
 endif
 
 if !exists('g:fauxClip_paste_cmd')
-    let g:fauxClip_paste_cmd = 'xclip -o -selection clipboard 2> /dev/null'
+    if executable('pbcopy')
+        let g:fauxClip_copy_cmd = 'pbpaste'
+    else
+        let g:fauxClip_paste_cmd = 'xclip -o -selection clipboard 2> /dev/null'
+    endif
 endif
 
 if !exists('g:fauxClip_copy_primary_cmd')
-    let g:fauxClip_copy_primary_cmd = 'xclip -f -i'
+    if executable('pbcopy')
+        let g:fauxClip_copy_cmd = 'pbcopy'
+    else
+        let g:fauxClip_copy_primary_cmd = 'xclip -f -i'
+    endif
 endif
 
 if !exists('g:fauxClip_paste_primary_cmd')
-    let g:fauxClip_paste_primary_cmd = 'xclip -o 2> /dev/null'
+    if executable('pbcopy')
+        let g:fauxClip_copy_cmd = 'pbpaste'
+    else
+        let g:fauxClip_paste_primary_cmd = 'xclip -o 2> /dev/null'
+    endif
 endif
 
 augroup fauxClipCmdWrapper

--- a/plugin/fauxClip.vim
+++ b/plugin/fauxClip.vim
@@ -1,7 +1,7 @@
 " fauxClip - Clipboard support without +clipboard
 " Maintainer:  Jorengarenar <https://joren.ga>
 
-if has("clipboard") || exists('g:loaded_fauxClip') || !exists('##TextYankPost') || !exists('##TextChanged') || !exists('##CmdlineLeave')
+if &cp || has("clipboard") || exists('g:loaded_fauxClip') || !exists('##TextYankPost') || !exists('##TextChanged') || !exists('##CmdlineLeave')
     finish
 endif
 

--- a/plugin/fauxClip.vim
+++ b/plugin/fauxClip.vim
@@ -1,7 +1,7 @@
 " fauxClip - Clipboard support without +clipboard
 " Maintainer:  Jorengarenar <https://joren.ga>
 
-if &cp || has("clipboard") || exists('g:loaded_fauxClip') || !exists('##TextChanged') || !exists('##CmdlineLeave')
+if &cp || has("clipboard") || exists('g:loaded_fauxClip') || !exists('##TextYankPost')  || !exists('##TextChanged') || !exists('##CmdlineLeave')
     finish
 endif
 

--- a/plugin/fauxClip.vim
+++ b/plugin/fauxClip.vim
@@ -1,7 +1,7 @@
 " fauxClip - Clipboard support without +clipboard
 " Maintainer:  Jorengarenar <https://joren.ga>
 
-if &cp || has("clipboard") || exists('g:loaded_fauxClip') || !exists('##TextYankPost') || !exists('##TextChanged') || !exists('##CmdlineLeave')
+if &cp || has("clipboard") || exists('g:loaded_fauxClip') || !exists('##TextChanged') || !exists('##CmdlineLeave')
     finish
 endif
 
@@ -15,7 +15,7 @@ endif
 
 if !exists('g:fauxClip_paste_cmd')
     if executable('pbcopy')
-        let g:fauxClip_copy_cmd = 'pbpaste'
+        let g:fauxClip_paste_cmd = 'pbpaste'
     else
         let g:fauxClip_paste_cmd = 'xclip -o -selection clipboard 2> /dev/null'
     endif
@@ -23,7 +23,7 @@ endif
 
 if !exists('g:fauxClip_copy_primary_cmd')
     if executable('pbcopy')
-        let g:fauxClip_copy_cmd = 'pbcopy'
+        let g:fauxClip_copy_primary_cmd = 'pbcopy'
     else
         let g:fauxClip_copy_primary_cmd = 'xclip -f -i'
     endif
@@ -31,7 +31,7 @@ endif
 
 if !exists('g:fauxClip_paste_primary_cmd')
     if executable('pbcopy')
-        let g:fauxClip_copy_cmd = 'pbpaste'
+        let g:fauxClip_paste_primary_cmd = 'pbpaste'
     else
         let g:fauxClip_paste_primary_cmd = 'xclip -o 2> /dev/null'
     endif

--- a/plugin/fauxClip.vim
+++ b/plugin/fauxClip.vim
@@ -1,7 +1,7 @@
 " fauxClip - Clipboard support without +clipboard
 " Maintainer:  Jorengarenar <https://joren.ga>
 
-if &cp || has("clipboard") || exists('g:loaded_fauxClip') || !exists('##TextYankPost')  || !exists('##TextChanged') || !exists('##CmdlineLeave')
+if &cp || has("clipboard") || exists('g:loaded_fauxClip') || !exists('##TextYankPost') || !exists('##TextChanged') || !exists('##CmdlineLeave')
     finish
 endif
 
@@ -39,7 +39,7 @@ endif
 
 augroup fauxClipCmdWrapper
     autocmd!
-    autocmd CmdlineLeave : if getcmdline() =~ "[dy].*[+*]" | call fauxClip#cmd_wrapper() | endif
+    autocmd CmdlineLeave : if getcmdline() =~# '[dyp]\w*\s*[+*]' | call fauxClip#cmd_wrapper() | endif
 augroup END
 
 nnoremap <expr> "* fauxClip#start("*")

--- a/plugin/fauxClip.vim
+++ b/plugin/fauxClip.vim
@@ -1,7 +1,7 @@
 " fauxClip - Clipboard support without +clipboard
 " Maintainer:  Jorengarenar <https://joren.ga>
 
-if has("clipboard") || exists('g:loaded_fauxClip')
+if has("clipboard") || exists('g:loaded_fauxClip') || !exists('##TextYankPost') || !exists('##TextChanged') || !exists('##CmdlineLeave')
     finish
 endif
 

--- a/plugin/fauxClip.vim
+++ b/plugin/fauxClip.vim
@@ -38,8 +38,8 @@ if !exists('g:fauxClip_paste_primary_cmd')
 endif
 
 augroup fauxClipCmdWrapper
-  autocmd!
-  autocmd CmdlineLeave : if getcmdline() =~ "[dy].*[+*]" | call fauxClip#cmd_wrapper() | endif
+    autocmd!
+    autocmd CmdlineLeave : if getcmdline() =~ "[dy].*[+*]" | call fauxClip#cmd_wrapper() | endif
 augroup END
 
 nnoremap <expr> "* fauxClip#start("*")


### PR DESCRIPTION
I have a made a few changes:

* Added documentation
* Support `:put`
* Simplified `:yank`/`:delete`/`:put` command support 
* Default to `pbcopy`/`pbpaste` when available
* Fallback to `CursorMoved` when `TextYankPost` is unavailable
* Check for `'nocp'` and event support