### PR TITLE
Fix generated variable name in plugin/fauxClip.vim

### DIFF
--- a/plugin/fauxClip.vim
+++ b/plugin/fauxClip.vim
@@ -8,7 +8,7 @@ let s:cpo_save = &cpo | set cpo&vim
 
 function s:init() abort
   let settedCmds = 0
-  for v in [ "copy", "copy_primary", "paste_cmd", "paste_primary" ]
+  for v in [ "copy", "copy_primary", "paste", "paste_primary" ]
     let settedCmds += exists("g:fauxClip_".v."_cmd")
   endfor
 


### PR DESCRIPTION
Hello!
Thanks for this simple and nice plugin :)
The first for loop checked for a variable that does not exist, resulting in an error and in my case no access to clipboard.